### PR TITLE
Fixed Unicode problem - write to stdout

### DIFF
--- a/bin/mutt-ics
+++ b/bin/mutt-ics
@@ -127,7 +127,7 @@ def main(args):
 
     cal = icalendar.Calendar.from_ical(ics_text)
     output = get_interesting_stuff(cal)
-    sys.stdout.write(output)
+    sys.stdout.write(output.encode('utf-8'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Missing stdout encoding into Unicode caused following error:

[-- Autoview stderr of python /usr/local/bin/mutt-ics.py --]
Traceback (most recent call last):
  File "/usr/local/bin/mutt-ics.py", line 135, in <module>
    main(sys.argv)
  File "/usr/local/bin/mutt-ics.py", line 130, in main
    sys.stdout.write(output)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u011b' in position 157: ordinal not in range(128)

The patch should fix this problem.