### PR TITLE
Fix Python 3 encoding issue

### DIFF
--- a/bin/mutt-ics
+++ b/bin/mutt-ics
@@ -122,12 +122,12 @@ def main(args):
         with codecs.open(args[1], 'rb', 'utf-8') as f:
             ics_text = get_ics_text(f)
     else:
-        stream = codecs.getreader("utf-8")(sys.stdin)
+        stream = codecs.getreader("utf-8")(sys.stdin.buffer)
         ics_text = get_ics_text(stream)
 
     cal = icalendar.Calendar.from_ical(ics_text)
     output = get_interesting_stuff(cal)
-    out_stream = codecs.getwriter("utf-8")(sys.stdout)
+    out_stream = codecs.getwriter("utf-8")(sys.stdout.buffer)
     out_stream.write(output)
 
 

--- a/bin/mutt-ics
+++ b/bin/mutt-ics
@@ -128,7 +128,7 @@ def main(args):
     cal = icalendar.Calendar.from_ical(ics_text)
     output = get_interesting_stuff(cal)
     out_stream = codecs.getwriter("utf-8")(sys.stdout.buffer)
-    out_stream.write(output)
+    out_stream.write(output + '\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This Pull Request fixes a pending encoding issue with Python 3.  When reading from `sys.stdin` or writing to `sys.stdout`, Python 3 works with plain text by default.  If binary data is to be read or written, the underlying binary `buffer` object has to be used.  Otherwise, you are running into this error when reading from standard input:

    Traceback (most recent call last):
      File "/home/igor/.local/bin/mutt-ics", line 135, in <module>
        main(sys.argv)
      File "/home/igor/.local/bin/mutt-ics", line 126, in main
        ics_text = get_ics_text(stream)
      File "/home/igor/.local/bin/mutt-ics", line 41, in get_ics_text
        content = f.read()
      File "/usr/lib64/python3.3/codecs.py", line 490, in read
        data = self.bytebuffer + newdata
    TypeError: can't concat bytes to str

Or this error when writing to standard output:

    Traceback (most recent call last):
      File "/home/igor/.local/bin/mutt-ics", line 135, in <module>
        main(sys.argv)
      File "/home/igor/.local/bin/mutt-ics", line 131, in main
        out_stream.write(output)
      File "/usr/lib64/python3.3/codecs.py", line 369, in write
        self.stream.write(data)
    TypeError: must be str, not bytes

Finally, I have also added a final newline, to ensure that the prompt starts in a new line if the script is used from the console.