### PR TITLE
Print times using local timezone rather than printing UTC time

### DIFF
--- a/bin/mutt-ics
+++ b/bin/mutt-ics
@@ -10,7 +10,7 @@ from dateutil import tz
 import icalendar
 
 
-datefmt = '%A, %d %B %Y, %H:%M'
+datefmt = '%A, %d %B %Y, %H:%M %Z'
 
 
 def compose(*functions):

--- a/bin/mutt-ics
+++ b/bin/mutt-ics
@@ -5,6 +5,7 @@ import re
 import sys
 from functools import partial, reduce
 from operator import add
+from dateutil import tz
 
 import icalendar
 
@@ -75,7 +76,7 @@ def identity(x):
 
 
 def format_date(x):
-    return x.dt.strftime(datefmt)
+    return x.dt.astimezone(tz.tzlocal()).strftime(datefmt)
 
 
 def get_event(e):


### PR DESCRIPTION
I'm not entirely sure about this because I don't understand why nobody else had a problem with this. That said, the change does make the times print as expected.